### PR TITLE
Exclude repository configuration from source tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*      	export-ignore
+.travis.yml	export-ignore


### PR DESCRIPTION
`.gitignore` is great when developing.
however, it sometimes becomes painful, when a downstream includes a source release
(as downloaded via the "Source code" link on the github release page) in their own git-repository.

e.g. when packaging for Debian, we definitely do want to see all build artifacts...


better to drop all repository and CI configurations from the source tarballs...